### PR TITLE
`import time` for import_records_chunked()

### DIFF
--- a/redcaphelper/connection.py
+++ b/redcaphelper/connection.py
@@ -17,6 +17,9 @@ from builtins import object
 
 import csv
 
+# for import_records_chunked()
+import time
+
 # Py2 vs py3
 try:
 	from StringIO import StringIO


### PR DESCRIPTION
time module wasn't being imported in previous releases. Used to run in to "NameError: name 'time' is not defined" error.